### PR TITLE
External package install routine [working]

### DIFF
--- a/integrator/sedfile
+++ b/integrator/sedfile
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+lne=$(sed -n '/project/=' $1/CMakeLists.txt)
+sed -i "$lne s/^/#/" "$1/CMakeLists.txt"
+


### PR DESCRIPTION
- Use [link](https://github.com/kiryteo/root-pkg/blob/master/manifest.yml) for the manifest.yml.
- Routine downloads the repository using url 
- Use of sed commands to modify CMakeLists.txt (commenting project() command)
- This is a simple use case to demonstrate external package routine  